### PR TITLE
Use PHP 7.4 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache-stretch
+FROM php:7.4-apache
 # MAINTAINER Austin St. Aubin <austinsaintaubin@gmail.com>
 
 # Build Environment Variables
@@ -11,7 +11,7 @@ RUN apt-get update
 # Install & Setup Dependencies
 RUN set -ex; \
     apt-get install -y curl iputils-ping; \
-    apt-get install zip unzip; \
+    apt-get install zip unzip git; \
     #docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr --with-png-dir=/usr --with-xpm-dir=/usr; \
     docker-php-ext-install pdo pdo_mysql mysqli sockets; \
     apt-get clean; \


### PR DESCRIPTION
PHP 7.4 is stable for a while - there're no contraindications for using it as a base image.
I've also added `git` to package list - absence was causing this error:
```
Installing php-pushover/php-pushover (dev-master b2d060e): Cloning b2d060efac
    Failed to download php-pushover/php-pushover from source: Failed to clone https://github.com/cschalenborgh/php-pushover.git, git was not found, check that it is installed and in your PATH env.

sh: 1: git: not found
```