### PR TITLE
Remove hardcoded DNS from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
       - MYSQL_DATABASE_PREFIX=psm_
     ports:
       - 8080:80
-    dns:
-      - 192.168.3.8
     links:
       - "db:database"
     volumes:


### PR DESCRIPTION
If there is no DNS service on 192.168.3.8, all hostname based checks will fail.

When no DNS is set in `docker-compose.yml`, the systems DNS settings is used, which should be the best solution for almost all setups.