### PR TITLE
Small improvments / bug fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!docker-entrypoint.sh
+!maria-wait.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,8 @@ RUN composer install --no-dev -o
 
 # Add Entrypoint & Start Commands
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY maria-wait.sh /usr/local/bin/
+
 RUN chmod u+rwx /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker run -d --name phpservermonitor_mariadb \
 
 Configuration should be automatic if the envirmental varable is set `PSM_AUTO_CONFIGURE=true`. Otherwise the configuration window should be prepopulated to the following.
 
-* **Database Host:** database
+* **Database Host:** db
 * **Database Name:** phpservermonitor
 * **Database User:** phpservermonitor
 * **Data Password:** YOUR_PASSWORD

--- a/README.md
+++ b/README.md
@@ -57,17 +57,20 @@ docker-compose up -d
 # Start Containers w/ Random Passwords
 export "MYSQL_ROOT_PASSWORD=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)" "MYSQL_PASSWORD=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
 
+# Create a network
+docker network create -d psm
+
 # phpservermonitor
 docker run -d --name phpservermonitor \
+  --network psm \
   --restart always \
-  --link phpservermonitor_mariadb \
   -v /sessions \
   --dns=192.168.3.8 \
   -p 8080:80 \
   -e TIME_ZONE='Europe/Amsterdam' \
   -e PSM_REFRESH_RATE_SECONDS=15 \
   -e PSM_AUTO_CONFIGURE=true \
-  -e MYSQL_HOST=database \
+  -e MYSQL_HOST=db \
   -e MYSQL_USER=phpservermonitor \
   -e MYSQL_PASSWORD=${MYSQL_PASSWORD} \
   -e MYSQL_DATABASE=phpservermonitor \
@@ -76,6 +79,7 @@ docker run -d --name phpservermonitor \
 
 # phpservermonitor_mariadb
 docker run -d --name phpservermonitor_mariadb \
+  --network psm --network-alias db \
   --restart always \
   -e MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD} \
   -e MYSQL_USER=phpservermonitor \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.8'
 services:
 
   phpservermonitor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 services:
 
   phpservermonitor:
+    build: .
     image: phpservermonitor:latest
     container_name: phpservermonitor
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,8 @@ services:
   #   container_name: phpservermonitor_phpmyadmin
   #   restart: always
   #   environment:
-  #     - MYSQL_HOST=database
+  #     - PMA_HOST=db
   #   ports:
   #     - 8081:80
   #   volumes:
   #     - /sessions
-  #   links:
-  #     - "db:database"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - MYSQL_USER=phpservermonitor
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=phpservermonitor
+    volumes:
+      - ./mariadb:/var/lib/mysql/phpservermonitor
 
   # phpmyadmin:
   #   image: phpmyadmin/phpmyadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - "db:database"
     volumes:
      - /sessions
+    depends_on:
+     - db
 
   db:
     image: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,13 @@ services:
       - TIME_ZONE='Europe/Amsterdam'
       - PSM_REFRESH_RATE_SECONDS=15
       - PSM_AUTO_CONFIGURE=true
-      - MYSQL_HOST=database
+      - MYSQL_HOST=db
       - MYSQL_USER=phpservermonitor
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=phpservermonitor
       - MYSQL_DATABASE_PREFIX=psm_
     ports:
       - 8080:80
-    links:
-      - "db:database"
     volumes:
      - /sessions
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -49,6 +49,9 @@ EOF
 
 fi
 
+# wait until mariadb is ready
+/usr/local/bin/maria-wait.sh
+
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then
 	set -- apache2-foreground "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,6 +50,7 @@ EOF
 fi
 
 # wait until mariadb is ready
+echo "Waiting until database is ready..."
 /usr/local/bin/maria-wait.sh
 
 # first arg is `-f` or `--some-option`

--- a/maria-wait.sh
+++ b/maria-wait.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+echo -n "Waiting until MariaDB has started"
+until (timeout 1 bash -c "< /dev/tcp/database/3306") &> /dev/null; do
+	echo -n .
+	sleep 1
+done
+echo

--- a/maria-wait.sh
+++ b/maria-wait.sh
@@ -3,7 +3,7 @@
 set -ueo pipefail
 
 echo -n "Waiting until MariaDB has started"
-until (timeout 1 bash -c "< /dev/tcp/database/3306") &> /dev/null; do
+until (timeout 1 bash -c "< /dev/tcp/db/3306") &> /dev/null; do
 	echo -n .
 	sleep 1
 done


### PR DESCRIPTION
I hope that it's okay to wrap these little changes in one PR.

**New:**

- Allow the usage of `docker-compose build`

**Bugfixes:**

- Start DB container first and wait until it's ready, before starting phpservermonitor. I noticed before, that there is a DB connection error shown in phpservermonitor, until MariaDB is ready.
- When doing `docker-compose down / up`, the MariaDB container is deleted and the configured data was lost.

**Improvement:**

- .dockerignore added