### PR TITLE
fix: repo url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mkdir -p "/tmp/php-server-monitor"
 cd "/tmp/php-server-monitor"
 
 # Clone Git Repo
-git clone https://github.com/phpservermon/phpservermon.git phpservermonitor
+git clone https://github.com/phpservermon/docker-phpservermonitor.git phpservermonitor
 cd phpservermonitor/
 
 # Build Docker Image


### PR DESCRIPTION
Hi Tim,

I just build the docker container for personal use and was very confused, that it didn't work as expected. The cause of this error is a wrong repo url in the readme file. It references the `phpservermonitor` repo instead of the `docker-phpservermonitor` repo ;)

Hope this helps others as well :)

Best regards